### PR TITLE
fix SearchRequest.decompileFilter stackoverflow When the is a FilterNot

### DIFF
--- a/message/struct_methods.go
+++ b/message/struct_methods.go
@@ -159,7 +159,7 @@ func (s *SearchRequest) decompileFilter(packet Filter) (ret string, err error) {
 		}
 	case FilterNot:
 		ret += "!"
-		childStr, err = s.decompileFilter(f)
+		childStr, err = s.decompileFilter(f.Filter)
 		if err != nil {
 			return
 		}


### PR DESCRIPTION
Hello lor00x, this is a fix for SearchRequest.decompileFilter which overflow when there is a FilterNot in Filter.

We can thank robert baruch who reported this bug with this fix.
