### PR TITLE
check bytes offset before readTaggedBOOLEAN

### DIFF
--- a/message/asn1.go
+++ b/message/asn1.go
@@ -40,8 +40,8 @@ var tagNames = map[int]string{
 	tagInteger:     "INTEGER",
 	tagOctetString: "OCTET STRING",
 	tagEnum:        "ENUM",
-	tagSequence: "SEQUENCE",
-	tagSet:      "SET",
+	tagSequence:    "SEQUENCE",
+	tagSet:         "SET",
 }
 
 const (

--- a/message/matching_rule_assertion.go
+++ b/message/matching_rule_assertion.go
@@ -29,6 +29,9 @@ func (matchingruleassertion *MatchingRuleAssertion) readComponents(bytes *Bytes)
 	if err != nil {
 		return LdapError{fmt.Sprintf("readComponents: %s", err.Error())}
 	}
+	if len(bytes.bytes) == bytes.offset {
+		return
+	}
 	matchingruleassertion.dnAttributes, err = readTaggedBOOLEAN(bytes, classContextSpecific, TagMatchingRuleAssertionDnAttributes)
 	if err != nil {
 		return LdapError{fmt.Sprintf("readComponents: %s", err.Error())}


### PR DESCRIPTION
https://ldapwiki.com/wiki/Microsoft%20Active%20Directory%20Extensible%20Match%20Rules
some client will not send dnAttributes, in this condtion, io read will hang.